### PR TITLE
add a WEBSITE_ROOT_URL env var check

### DIFF
--- a/src/_data/meta.js
+++ b/src/_data/meta.js
@@ -1,5 +1,5 @@
 module.exports = {
-    url: process.env.CF_PAGES_URL || "https://localhost:8080",
+    url: process.env.WEBSITE_ROOT_URL || process.env.CF_PAGES_URL || "https://localhost:8080",
     siteName: "dankulla",
     siteDescription: "Some things I've worked on and want to show off",
     contactFormUrl: "https://docs.google.com/forms/d/e/1FAIpQLSdaQhOo7PRsiZp9GGPfy4dedtofm5VQRVJE89_3ODSVIfyAsg/viewform?usp=sf_link"


### PR DESCRIPTION
this will let the production deployment interpolate the correct,
permanent website root url in all of the links