### PR TITLE
look for njk files explicitly

### DIFF
--- a/src/css/tailwind.config.js
+++ b/src/css/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  content: ['public/**/*.html'],
+  content: ['public/**/*.{html,njk}'],
   safelist: [],
   theme: {
     extend: {


### PR DESCRIPTION
I think that the build process on cloudflare pages didn't know to look for njk files for utility class uses (e.g. responsive breakpoints). changing the content in the tailwind config file to include `njk` files made the branch deploy css work properly

see [the branch deploy of this branch](https://afc4ef3e.portfolio-website-f33.pages.dev/)